### PR TITLE
input フォーカス時のアウトラインを削除

### DIFF
--- a/src/components/TodaysToDo.jsx
+++ b/src/components/TodaysToDo.jsx
@@ -12,7 +12,7 @@ const Input = ({ name, register, onBlurFunc, defaultValue }) => (
     autoFocus
     defaultValue={defaultValue}
     onBlur={onBlurFunc}
-    className="caret-primary outline-primary p-2 rounded w-full"
+    className="caret-primary outline-none p-2 rounded w-full"
   />
 );
 


### PR DESCRIPTION
## Issues

#18  <- issue 番号を書き換える

## 変更内容

- input にフォーカスが当たっている時のアウトラインを削除しました。

## 補足

## 画面スクリーンショットなど
<img width="217" alt="スクリーンショット 2022-02-23 19 35 00" src="https://user-images.githubusercontent.com/79145642/155302941-09290455-723b-49a3-908b-46c9c6502943.png">

