### PR TITLE
プロフィールページ作成。

### DIFF
--- a/src/pages/account/profilesettings/index.jsx
+++ b/src/pages/account/profilesettings/index.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Layout } from 'src/layouts/Layout';
+import Image from 'next/image';
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/outline';
+
+const Profile = () => {
+	return (
+		<Layout>
+			<div className='max-w-2xl mx-auto px-6'>
+				<div className='lg:hidden flex items-center relative justify-between gap-x-6 mb-8'>
+					<ChevronLeftIcon className='w-6 h-6' />
+					<h1 className='text-lg font-bold'>プロフィール設定</h1>
+					<span></span>
+				</div>
+				<div className='hidden lg:block'>
+					<ul className='flex items-center gap-x-8 text-sm font-bold mb-4'>
+						<li>ホーム</li>
+						<ChevronRightIcon className='w-4 h-4 text-gray-400' />
+						<li>プロフィール</li>
+					</ul>
+					<h1 className='text-3xl font-bold mb-8'>プロフィール</h1>
+				</div>
+				<form action=''>
+					<label className='text-gray-400 font-bold text-sm'>アイコン</label>
+					<div className='flex items-center gap-x-4 mt-2 mb-9'>
+						<Image
+							src='/person.png'
+							alt=''
+							width='100'
+							height='100'
+							className='h-auto aspect-square'
+						/>
+						<button className='px-4 py-2 bg-gray-100 rounded-2xl text-xs font-bold'>
+							変更する
+						</button>
+					</div>
+					<label className='text-gray-400 font-bold text-sm' htmlFor='name'>
+						名前
+					</label>
+					<input
+						className='block w-full h-11 px-4 mt-1 bg-gray-100 rounded-xl'
+						type='text'
+						name='name'
+						id='name'
+						placeholder='しまぶー'
+					/>
+					<button className='block w-full h-14 mt-9 bg-blue-600 rounded-3xl text-white'>
+						保存する
+					</button>
+				</form>
+			</div>
+		</Layout>
+	);
+};
+
+export default Profile;


### PR DESCRIPTION
## Issues

#23 

## 変更内容

- プロフィールページ作成

## 補足
- PCのパンくずリスト+h1、モバイルのナビゲーション+h1はブレークポイントで出し分けしています。違和感あるのですが、全く別の情報構造とスタイルのため、とりあえず両方書きました。

## 画面スクリーンショットなど
![20451a7d15953cf14db6f16c6d0ad7e9](https://user-images.githubusercontent.com/14804989/155941126-308251b6-02df-4cdf-9960-d4e84716418f.png)
![8d86211f52bb5a8e14f1bf3870ff9731](https://user-images.githubusercontent.com/14804989/155941164-ce1bc784-66bc-4877-a0d9-1a04ea71605c.png)

